### PR TITLE
refactor: update dependencies, run linter, remove extra dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-swf-player",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6186,16 +6186,6 @@
           "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
           "dev": true
         }
-      }
-    },
-    "style-loader": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-2.0.0.tgz",
-      "integrity": "sha512-Z0gYUJmzZ6ZdRUqpg1r8GsaFKypE+3xAzuFeMuoHgjc9KZv3wMyCRjQIWEbhoFSq7+7yoHXySDJyyWQaPajeiQ==",
-      "dev": true,
-      "requires": {
-        "loader-utils": "^2.0.0",
-        "schema-utils": "^3.0.0"
       }
     },
     "sudo-prompt": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1043,12 +1043,6 @@
       "integrity": "sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A==",
       "dev": true
     },
-    "@types/json-schema": {
-      "version": "7.0.7",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
-      "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
-      "dev": true
-    },
     "@types/keyv": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.1.tgz",
@@ -1137,12 +1131,6 @@
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
       }
-    },
-    "ajv-keywords": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true
     },
     "ansi-colors": {
       "version": "4.1.1",
@@ -1433,12 +1421,6 @@
       "requires": {
         "tweetnacl": "^0.14.3"
       }
-    },
-    "big.js": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
-      "dev": true
     },
     "bl": {
       "version": "4.1.0",
@@ -2697,12 +2679,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
-    },
-    "emojis-list": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
       "dev": true
     },
     "encodeurl": {
@@ -4188,15 +4164,6 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
-    "json5": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.5"
-      }
-    },
     "jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -4316,17 +4283,6 @@
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
-      }
-    },
-    "loader-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-      "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
-      "dev": true,
-      "requires": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^2.1.2"
       }
     },
     "locate-path": {
@@ -4840,16 +4796,6 @@
             "glob": "^7.1.3"
           }
         }
-      }
-    },
-    "node-loader": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/node-loader/-/node-loader-1.0.3.tgz",
-      "integrity": "sha512-8c9ef5q24F0AjrPxUjdX7qdTlsU1zZCPeqYvSBCH1TJko3QW4qu1uA1C9KbOPdaRQwREDdbSYZgltBAlbV7l5g==",
-      "dev": true,
-      "requires": {
-        "loader-utils": "^2.0.0",
-        "schema-utils": "^3.0.0"
       }
     },
     "node-pre-gyp": {
@@ -5921,17 +5867,6 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
-    },
-    "schema-utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
-      "integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
-      "dev": true,
-      "requires": {
-        "@types/json-schema": "^7.0.6",
-        "ajv": "^6.12.5",
-        "ajv-keywords": "^3.5.2"
-      }
     },
     "semver": {
       "version": "7.3.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -574,6 +574,12 @@
             "type-fest": "^0.8.1"
           }
         },
+        "ignore": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+          "dev": true
+        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -1803,9 +1809,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.13.0.tgz",
-      "integrity": "sha512-iWDbiyha1M5vFwPFmQnvRv+tJzGbFAm6XimJUT0NgHYW3xZEs1SkCAcasWSVFxpI2Xb/V1DDJckq3v90+bQnog==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.13.1.tgz",
+      "integrity": "sha512-JqveUc4igkqwStL2RTRn/EPFGBOfEZHxJl/8ej1mXJR75V3go2mFF4bmUYkEIT1rveHKnkUlcJX/c+f1TyIovQ==",
       "dev": true,
       "optional": true
     },
@@ -2869,6 +2875,12 @@
             "ms": "2.1.2"
           }
         },
+        "ignore": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+          "dev": true
+        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -3725,14 +3737,6 @@
         "ignore": "^5.1.4",
         "merge2": "^1.3.0",
         "slash": "^3.0.0"
-      },
-      "dependencies": {
-        "ignore": {
-          "version": "5.1.8",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-          "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
-          "dev": true
-        }
       }
     },
     "got": {
@@ -3899,9 +3903,9 @@
       "dev": true
     },
     "ignore": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
       "dev": true
     },
     "ignore-walk": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,13 +98,13 @@
       }
     },
     "@electron-forge/async-ora": {
-      "version": "6.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@electron-forge/async-ora/-/async-ora-6.0.0-beta.54.tgz",
-      "integrity": "sha512-OCoHds0BIXaB54HgKw6pjlHC1cnaTcfJfVVkPSJl1GLC3VShZ5bETJfsitwbiP2kbfKLUQFayW27sqbwnwQR2w==",
+      "version": "6.0.0-beta.57",
+      "resolved": "https://registry.npmjs.org/@electron-forge/async-ora/-/async-ora-6.0.0-beta.57.tgz",
+      "integrity": "sha512-pinf6bB5etIKNwFgMx2V+kwsFlkjU4mApALv0Jn/lmcH5dlAB4zPwuKTccC44xVO4pp/bV1HWb1XJ4lHVxYaJg==",
       "dev": true,
       "requires": {
         "colors": "^1.4.0",
-        "debug": "^4.1.0",
+        "debug": "^4.3.1",
         "log-symbols": "^4.0.0",
         "ora": "^5.0.0",
         "pretty-ms": "^7.0.0"
@@ -128,20 +128,20 @@
       }
     },
     "@electron-forge/cli": {
-      "version": "6.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@electron-forge/cli/-/cli-6.0.0-beta.54.tgz",
-      "integrity": "sha512-+Ui1BI8c5CnBawH2OEySa5QR8DzrFd/I9FHlClvrTsIDfsBAeMSv9NTbSNcmo9Af5kI+aNsLQa8tp1vD8DNrng==",
+      "version": "6.0.0-beta.57",
+      "resolved": "https://registry.npmjs.org/@electron-forge/cli/-/cli-6.0.0-beta.57.tgz",
+      "integrity": "sha512-ouIL3FI6C0W3iLwwwQzKufjoP/OZagUDMCDjGLN/dqeg+lZ+cR40bdfaNTFha9ajz+zSe2SmhCOMVUVNNkJ5Sg==",
       "dev": true,
       "requires": {
-        "@electron-forge/async-ora": "6.0.0-beta.54",
-        "@electron-forge/core": "6.0.0-beta.54",
-        "@electron-forge/shared-types": "6.0.0-beta.54",
+        "@electron-forge/async-ora": "6.0.0-beta.57",
+        "@electron-forge/core": "6.0.0-beta.57",
+        "@electron-forge/shared-types": "6.0.0-beta.57",
         "@electron/get": "^1.9.0",
         "colors": "^1.4.0",
         "commander": "^4.1.1",
-        "debug": "^4.1.0",
-        "fs-extra": "^9.0.1",
-        "inquirer": "^7.3.3",
+        "debug": "^4.3.1",
+        "fs-extra": "^10.0.0",
+        "inquirer": "^8.0.0",
         "semver": "^7.2.1"
       },
       "dependencies": {
@@ -163,34 +163,34 @@
       }
     },
     "@electron-forge/core": {
-      "version": "6.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@electron-forge/core/-/core-6.0.0-beta.54.tgz",
-      "integrity": "sha512-yggZeiwRLnIsQYCT5jKhx2L7I02CwUCjnIzA+CqUZXD0AU1c2o0BA/26dNOGvY/+pr5yWjOXcrGy1hvj3dnLmQ==",
+      "version": "6.0.0-beta.57",
+      "resolved": "https://registry.npmjs.org/@electron-forge/core/-/core-6.0.0-beta.57.tgz",
+      "integrity": "sha512-pLYG0QefjAEjxRazgEjryb4TrxVeebGTqXqZsKOpABAlDaKU4EmBq06SeSu8H9IAzMPwzpDIa6PaXdkMclqhnA==",
       "dev": true,
       "requires": {
-        "@electron-forge/async-ora": "6.0.0-beta.54",
-        "@electron-forge/installer-base": "6.0.0-beta.54",
-        "@electron-forge/installer-deb": "6.0.0-beta.54",
-        "@electron-forge/installer-dmg": "6.0.0-beta.54",
-        "@electron-forge/installer-exe": "6.0.0-beta.54",
-        "@electron-forge/installer-rpm": "6.0.0-beta.54",
-        "@electron-forge/installer-zip": "6.0.0-beta.54",
-        "@electron-forge/maker-base": "6.0.0-beta.54",
-        "@electron-forge/plugin-base": "6.0.0-beta.54",
-        "@electron-forge/publisher-base": "6.0.0-beta.54",
-        "@electron-forge/shared-types": "6.0.0-beta.54",
-        "@electron-forge/template-base": "6.0.0-beta.54",
-        "@electron-forge/template-typescript": "6.0.0-beta.54",
-        "@electron-forge/template-typescript-webpack": "6.0.0-beta.54",
-        "@electron-forge/template-webpack": "6.0.0-beta.54",
+        "@electron-forge/async-ora": "6.0.0-beta.57",
+        "@electron-forge/installer-base": "6.0.0-beta.57",
+        "@electron-forge/installer-deb": "6.0.0-beta.57",
+        "@electron-forge/installer-dmg": "6.0.0-beta.57",
+        "@electron-forge/installer-exe": "6.0.0-beta.57",
+        "@electron-forge/installer-rpm": "6.0.0-beta.57",
+        "@electron-forge/installer-zip": "6.0.0-beta.57",
+        "@electron-forge/maker-base": "6.0.0-beta.57",
+        "@electron-forge/plugin-base": "6.0.0-beta.57",
+        "@electron-forge/publisher-base": "6.0.0-beta.57",
+        "@electron-forge/shared-types": "6.0.0-beta.57",
+        "@electron-forge/template-base": "6.0.0-beta.57",
+        "@electron-forge/template-typescript": "6.0.0-beta.57",
+        "@electron-forge/template-typescript-webpack": "6.0.0-beta.57",
+        "@electron-forge/template-webpack": "6.0.0-beta.57",
         "@electron/get": "^1.9.0",
-        "@malept/cross-spawn-promise": "^1.1.0",
+        "@malept/cross-spawn-promise": "^1.1.1",
         "colors": "^1.4.0",
-        "debug": "^4.1.0",
+        "debug": "^4.3.1",
         "electron-packager": "^15.0.0",
-        "electron-rebuild": "^2.0.3",
+        "electron-rebuild": "^2.3.2",
         "find-up": "^5.0.0",
-        "fs-extra": "^9.0.1",
+        "fs-extra": "^10.0.0",
         "glob": "^7.1.5",
         "lodash": "^4.17.20",
         "log-symbols": "^4.0.0",
@@ -222,45 +222,45 @@
       }
     },
     "@electron-forge/installer-base": {
-      "version": "6.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@electron-forge/installer-base/-/installer-base-6.0.0-beta.54.tgz",
-      "integrity": "sha512-q6Z5kBAE6StKqn+3Z5tXVHu7WGCb9OMeIomw9H9Q41UUIehF7V0J3tCWTkJdhZ8D6/tkXcis3GKptaj0wfMpyg==",
+      "version": "6.0.0-beta.57",
+      "resolved": "https://registry.npmjs.org/@electron-forge/installer-base/-/installer-base-6.0.0-beta.57.tgz",
+      "integrity": "sha512-qeQMUos0WADEddSGhViCUeMswsFz1IL+elIy5h06AxgjoRtOU75VVy9RgVfDAMIN0iKvEWNKLQz1CBUtVAt0fA==",
       "dev": true,
       "requires": {
-        "@electron-forge/async-ora": "6.0.0-beta.54"
+        "@electron-forge/async-ora": "6.0.0-beta.57"
       }
     },
     "@electron-forge/installer-darwin": {
-      "version": "6.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@electron-forge/installer-darwin/-/installer-darwin-6.0.0-beta.54.tgz",
-      "integrity": "sha512-kRbH24+QBhbcIugnIvevnf43JGzLFLoyFsoY3YeyZeeDL3vfyg0vtSyUx0hfq1GpHG+zObDf3o18c3WbxdXlXA==",
+      "version": "6.0.0-beta.57",
+      "resolved": "https://registry.npmjs.org/@electron-forge/installer-darwin/-/installer-darwin-6.0.0-beta.57.tgz",
+      "integrity": "sha512-3dsa948r3gCkD+ooKeGwWSUyh5GEJ7ngi9t1dRD+f1jUnkU1e3SqcGXH68dr5NYn3OcsFDWreK3xvx/1qdEQAg==",
       "dev": true,
       "requires": {
-        "@electron-forge/async-ora": "6.0.0-beta.54",
-        "@electron-forge/installer-base": "6.0.0-beta.54",
-        "fs-extra": "^9.0.1",
+        "@electron-forge/async-ora": "6.0.0-beta.57",
+        "@electron-forge/installer-base": "6.0.0-beta.57",
+        "fs-extra": "^10.0.0",
         "sudo-prompt": "^9.1.1"
       }
     },
     "@electron-forge/installer-deb": {
-      "version": "6.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@electron-forge/installer-deb/-/installer-deb-6.0.0-beta.54.tgz",
-      "integrity": "sha512-UbJR2Md0SBqex5AIv9YZ56hY2Iz5gZ6f1iAx0q4PlYpCY19W9nRXdudLNhx1w5go26DsT53+h6EzX2NGpBLq3Q==",
+      "version": "6.0.0-beta.57",
+      "resolved": "https://registry.npmjs.org/@electron-forge/installer-deb/-/installer-deb-6.0.0-beta.57.tgz",
+      "integrity": "sha512-Dnm68RUwR0UEe1hq1OPWso0LwdkZTa7Rpv0m9bHl+IvXTmrU//S5fdHEtjHAmto8f8PD5VadsLQcxsc3bQVNGQ==",
       "dev": true,
       "requires": {
-        "@electron-forge/installer-linux": "6.0.0-beta.54"
+        "@electron-forge/installer-linux": "6.0.0-beta.57"
       }
     },
     "@electron-forge/installer-dmg": {
-      "version": "6.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@electron-forge/installer-dmg/-/installer-dmg-6.0.0-beta.54.tgz",
-      "integrity": "sha512-F9jwhUTzdFNlbLus7RQ8paoGPryr79JFYDLi42f0dyuFwlOjwlrA1wN5xWqrvcMeqFlc3DfjjeRWZ+10RQyorA==",
+      "version": "6.0.0-beta.57",
+      "resolved": "https://registry.npmjs.org/@electron-forge/installer-dmg/-/installer-dmg-6.0.0-beta.57.tgz",
+      "integrity": "sha512-kmAYga2yY5JcrRI3Dtpau5Ldsebzs4pGkCCBJqq5asqgDGdCpw+8Cky6ouJDaZMl853C0CEnqxeoGYDTAlVBKA==",
       "dev": true,
       "requires": {
-        "@electron-forge/installer-darwin": "6.0.0-beta.54",
-        "@malept/cross-spawn-promise": "^1.1.0",
-        "debug": "^4.1.0",
-        "fs-extra": "^9.0.1"
+        "@electron-forge/installer-darwin": "6.0.0-beta.57",
+        "@malept/cross-spawn-promise": "^1.1.1",
+        "debug": "^4.3.1",
+        "fs-extra": "^10.0.0"
       },
       "dependencies": {
         "debug": {
@@ -281,142 +281,142 @@
       }
     },
     "@electron-forge/installer-exe": {
-      "version": "6.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@electron-forge/installer-exe/-/installer-exe-6.0.0-beta.54.tgz",
-      "integrity": "sha512-PE7RBPerSenNcSkKXJWpervKNl7AVT+JeMzx61OHUQSw3h63NHRvXWh31llxk32mmJcaKRgGle2GsWob87Lv/w==",
+      "version": "6.0.0-beta.57",
+      "resolved": "https://registry.npmjs.org/@electron-forge/installer-exe/-/installer-exe-6.0.0-beta.57.tgz",
+      "integrity": "sha512-hVh4vh2q7BxJ8npsVCSxSdoUMwQwcs0LidbanXK8CqHmTgnb9MNDSHomCxOnX+kMQX85mCj9Nc5ROviXnLN4Xg==",
       "dev": true,
       "requires": {
-        "@electron-forge/installer-base": "6.0.0-beta.54",
-        "open": "^7.2.1"
+        "@electron-forge/installer-base": "6.0.0-beta.57",
+        "open": "^8.1.0"
       }
     },
     "@electron-forge/installer-linux": {
-      "version": "6.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@electron-forge/installer-linux/-/installer-linux-6.0.0-beta.54.tgz",
-      "integrity": "sha512-WQVV5fitsfTyktjb18m9Bx+Dho6rCFvVILqFNZAu1RfXIsjLl/h0WdkozdGDccfeDMqlRYmaNs3e5THn5swnAg==",
+      "version": "6.0.0-beta.57",
+      "resolved": "https://registry.npmjs.org/@electron-forge/installer-linux/-/installer-linux-6.0.0-beta.57.tgz",
+      "integrity": "sha512-MTK4wLCWxYctzo/htghNhZ5ptIf46AE3UdeQItjiEhL4+KjJjQN8JAVkl40WeM+rUDA53WRQ35HeykNBmspb6A==",
       "dev": true,
       "requires": {
-        "@electron-forge/installer-base": "6.0.0-beta.54",
+        "@electron-forge/installer-base": "6.0.0-beta.57",
         "sudo-prompt": "^9.1.1"
       }
     },
     "@electron-forge/installer-rpm": {
-      "version": "6.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@electron-forge/installer-rpm/-/installer-rpm-6.0.0-beta.54.tgz",
-      "integrity": "sha512-8gaJA2m8+Y/ZhV4xEeijXz8UksrliMEzyUAdwM5ZdAsmfmGlnhchGr0L6rI23D66dQP9DeyvUIuUwXrsTlj1nQ==",
+      "version": "6.0.0-beta.57",
+      "resolved": "https://registry.npmjs.org/@electron-forge/installer-rpm/-/installer-rpm-6.0.0-beta.57.tgz",
+      "integrity": "sha512-cTzL6mwkhKEkl4v7NE2ATaEsptf5OhTbtwb/tRVIuEOblYKTxw3x9nnH8iGJ73xPW/54awGiU1kHJTKA6UhcUA==",
       "dev": true,
       "requires": {
-        "@electron-forge/installer-linux": "6.0.0-beta.54"
+        "@electron-forge/installer-linux": "6.0.0-beta.57"
       }
     },
     "@electron-forge/installer-zip": {
-      "version": "6.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@electron-forge/installer-zip/-/installer-zip-6.0.0-beta.54.tgz",
-      "integrity": "sha512-KCY5zreA79wjZODhLmtrbFweTWdlh9JgmW9WruIrmHm3sK19rRhCdaZ+Dg5ZWUhMx2A79d5a2C7r78lWGcHl7A==",
+      "version": "6.0.0-beta.57",
+      "resolved": "https://registry.npmjs.org/@electron-forge/installer-zip/-/installer-zip-6.0.0-beta.57.tgz",
+      "integrity": "sha512-ip/mlC32/mdUzFsM/39cZWshLN1B1f6atYHd2OpXlyAz6IZWrRHdsrJGtYsGdpgeoV/wMm09MTyuKXku3ehPaQ==",
       "dev": true,
       "requires": {
-        "@electron-forge/installer-darwin": "6.0.0-beta.54",
-        "@malept/cross-spawn-promise": "^1.1.0",
-        "fs-extra": "^9.0.1"
+        "@electron-forge/installer-darwin": "6.0.0-beta.57",
+        "@malept/cross-spawn-promise": "^1.1.1",
+        "fs-extra": "^10.0.0"
       }
     },
     "@electron-forge/maker-base": {
-      "version": "6.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@electron-forge/maker-base/-/maker-base-6.0.0-beta.54.tgz",
-      "integrity": "sha512-4y0y15ieb1EOR5mibtFM9tZzaShbAO0RZu6ARLCpD5BgKuJBzXRPfWvEmY6WeDNzoWTJ+mQdYikLAeOL2E9mew==",
+      "version": "6.0.0-beta.57",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-base/-/maker-base-6.0.0-beta.57.tgz",
+      "integrity": "sha512-VnoSCeyCHBv9q0Bz9JRgKC1b4k3z/Qb2T9DrpMqEVW6ClZVkOAZVmjyEtb+Xn8DnRPc4UtSjpAquycC/AZJ4MQ==",
       "dev": true,
       "requires": {
-        "@electron-forge/shared-types": "6.0.0-beta.54",
-        "fs-extra": "^9.0.1",
+        "@electron-forge/shared-types": "6.0.0-beta.57",
+        "fs-extra": "^10.0.0",
         "which": "^2.0.2"
       }
     },
     "@electron-forge/maker-deb": {
-      "version": "6.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@electron-forge/maker-deb/-/maker-deb-6.0.0-beta.54.tgz",
-      "integrity": "sha512-PEAYULi7n/JkwvaEQnM554ewmLYkxGtHvuh6vUf5wsh48Xw3jcEVHejsc4FDjx5I6cKAByb9nscTtZpKt3ngXw==",
+      "version": "6.0.0-beta.57",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-deb/-/maker-deb-6.0.0-beta.57.tgz",
+      "integrity": "sha512-TfG5CxLIWtip0RDGnj88y9vgqJO+iexDoc2Lo3huCgYxHl/AgI8PTLFz/nnpmJChsno5MUv6Wf4xcu5Ln65Jfg==",
       "dev": true,
       "requires": {
-        "@electron-forge/maker-base": "6.0.0-beta.54",
-        "@electron-forge/shared-types": "6.0.0-beta.54",
+        "@electron-forge/maker-base": "6.0.0-beta.57",
+        "@electron-forge/shared-types": "6.0.0-beta.57",
         "electron-installer-debian": "^3.0.0"
       }
     },
     "@electron-forge/maker-rpm": {
-      "version": "6.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@electron-forge/maker-rpm/-/maker-rpm-6.0.0-beta.54.tgz",
-      "integrity": "sha512-6nqBOUnojRE8+KdvE8zVXN2/H/V/QuWJQ4cwCLahJQxG1kG5RXOh6VbsM1mEFxjJwOhVnK+wkNCODf1qi56JZw==",
+      "version": "6.0.0-beta.57",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-rpm/-/maker-rpm-6.0.0-beta.57.tgz",
+      "integrity": "sha512-ZfnJqY9waLef09zlyjWV6jfH1F6ejCPrEULLU4bgcISQJ1JlR/zBlAw6ug3vIeMT7WYxTOOObHKPnnddWmfMmQ==",
       "dev": true,
       "requires": {
-        "@electron-forge/maker-base": "6.0.0-beta.54",
-        "@electron-forge/shared-types": "6.0.0-beta.54",
+        "@electron-forge/maker-base": "6.0.0-beta.57",
+        "@electron-forge/shared-types": "6.0.0-beta.57",
         "electron-installer-redhat": "^3.2.0"
       }
     },
     "@electron-forge/maker-squirrel": {
-      "version": "6.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@electron-forge/maker-squirrel/-/maker-squirrel-6.0.0-beta.54.tgz",
-      "integrity": "sha512-JJ+HmUe94zZ6mZnyv3IvNLQ5nwoj4dcQ4gzwps4P3fCEpuABMr74KOlza7fMXrrs8cwOrGfMFwsk80GTcLdWkg==",
+      "version": "6.0.0-beta.57",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-squirrel/-/maker-squirrel-6.0.0-beta.57.tgz",
+      "integrity": "sha512-670nBYgA0I3Hc+wiOXnaRTXrwIL907VqEpLF5vtQLQ+sCoUmRZ4fcl5wmQCVvYd4J50bDrjDNTXFeDwB9PNCTQ==",
       "dev": true,
       "requires": {
-        "@electron-forge/maker-base": "6.0.0-beta.54",
-        "@electron-forge/shared-types": "6.0.0-beta.54",
-        "electron-winstaller": "^4.0.1",
-        "fs-extra": "^9.0.1"
+        "@electron-forge/maker-base": "6.0.0-beta.57",
+        "@electron-forge/shared-types": "6.0.0-beta.57",
+        "electron-winstaller": "^5.0.0",
+        "fs-extra": "^10.0.0"
       }
     },
     "@electron-forge/maker-zip": {
-      "version": "6.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@electron-forge/maker-zip/-/maker-zip-6.0.0-beta.54.tgz",
-      "integrity": "sha512-wbJhK1rDOCZMTtKrjvavT8R+Yi+v/6axsnTXvzbkzzMQ0xADKNslTwzO6mmbBJea4oIbYmQ44DRAjI21TNyQ/A==",
+      "version": "6.0.0-beta.57",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-zip/-/maker-zip-6.0.0-beta.57.tgz",
+      "integrity": "sha512-5EcCN/tD6EBmA5oD/hQOTRENKq12vp6S8HgVXNib6CtVrnGVVLYukiqJ8NGC7S/0VMTO+NtZyHax21+xnuk6TA==",
       "dev": true,
       "requires": {
-        "@electron-forge/maker-base": "6.0.0-beta.54",
-        "@electron-forge/shared-types": "6.0.0-beta.54",
-        "cross-zip": "^3.0.0",
-        "fs-extra": "^9.0.1"
+        "@electron-forge/maker-base": "6.0.0-beta.57",
+        "@electron-forge/shared-types": "6.0.0-beta.57",
+        "cross-zip": "^4.0.0",
+        "fs-extra": "^10.0.0"
       }
     },
     "@electron-forge/plugin-base": {
-      "version": "6.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@electron-forge/plugin-base/-/plugin-base-6.0.0-beta.54.tgz",
-      "integrity": "sha512-8HwGzgNCHo2PgUfNnTch3Gvj7l6fqOgjnARK1y056UfsxFy+hwvHaAO+7LLfr7ktNwU/bH3hGhOpE+ZmBSwSqQ==",
+      "version": "6.0.0-beta.57",
+      "resolved": "https://registry.npmjs.org/@electron-forge/plugin-base/-/plugin-base-6.0.0-beta.57.tgz",
+      "integrity": "sha512-lErdgdSGd+HcIzXsZC1Pf6VuLYsDVHTwFUzuZqUPdl28AOWKfwW+XpIZoPMDt2/Mdd5K0mCcYSylikcSa8RHYA==",
       "dev": true,
       "requires": {
-        "@electron-forge/shared-types": "6.0.0-beta.54"
+        "@electron-forge/shared-types": "6.0.0-beta.57"
       }
     },
     "@electron-forge/publisher-base": {
-      "version": "6.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@electron-forge/publisher-base/-/publisher-base-6.0.0-beta.54.tgz",
-      "integrity": "sha512-Dny0jW0N8QcNYKHTtzQFZD4pBWJ7tclJWf3ZCX031vUKG7RhThdA06IPNzV6JtWJswrvAE9TPndzZONMza2V7g==",
+      "version": "6.0.0-beta.57",
+      "resolved": "https://registry.npmjs.org/@electron-forge/publisher-base/-/publisher-base-6.0.0-beta.57.tgz",
+      "integrity": "sha512-eJFVt4JI/zCw86PMu/LERMAMVcPchyFfZ9upFec4YuOOMLaJH1NvbO3gGgYj7vavH1hQWZA6Yn7u8b+E8y8Byw==",
       "dev": true,
       "requires": {
-        "@electron-forge/shared-types": "6.0.0-beta.54"
+        "@electron-forge/shared-types": "6.0.0-beta.57"
       }
     },
     "@electron-forge/shared-types": {
-      "version": "6.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-6.0.0-beta.54.tgz",
-      "integrity": "sha512-6CzWKFR17rxxeIqm1w5ZyT9uTAHSVAjhqL8c+TmizF2703GyCEusUkjP2UXt/tZNY4MJlukZoJM66Bct6oZJ+w==",
+      "version": "6.0.0-beta.57",
+      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-6.0.0-beta.57.tgz",
+      "integrity": "sha512-8jRAf7HsfQC5BA8MTOwh8cXmqJ8JJqzO7WzDW9A50tHOKbpBxPW9YM8036SZzZ4GNZYBSWmJt3d3vW+KFLeYXg==",
       "dev": true,
       "requires": {
-        "@electron-forge/async-ora": "6.0.0-beta.54",
+        "@electron-forge/async-ora": "6.0.0-beta.57",
         "electron-packager": "^15.0.0",
-        "electron-rebuild": "^2.0.3",
+        "electron-rebuild": "^2.3.2",
         "ora": "^5.0.0"
       }
     },
     "@electron-forge/template-base": {
-      "version": "6.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@electron-forge/template-base/-/template-base-6.0.0-beta.54.tgz",
-      "integrity": "sha512-LuSpeOiM6AzUbamz5U/NqRkn4y7dzof1JK1ISAb+6tORf7JU014aKqDcLdwgP8Lxaz6P1bdlMmNJTvg5+SBrEw==",
+      "version": "6.0.0-beta.57",
+      "resolved": "https://registry.npmjs.org/@electron-forge/template-base/-/template-base-6.0.0-beta.57.tgz",
+      "integrity": "sha512-3Nc7ik99VHQK8eTUrO/lA2tMRM5a0fLX+GgjR32yzkaAv081qd6t/XWS7MfU3k5Ld5cYMturUywJnEP/QdxOvA==",
       "dev": true,
       "requires": {
-        "@electron-forge/async-ora": "6.0.0-beta.54",
-        "@electron-forge/shared-types": "6.0.0-beta.54",
-        "debug": "^4.1.0",
-        "fs-extra": "^9.0.1",
+        "@electron-forge/async-ora": "6.0.0-beta.57",
+        "@electron-forge/shared-types": "6.0.0-beta.57",
+        "debug": "^4.3.1",
+        "fs-extra": "^10.0.0",
         "username": "^5.1.0"
       },
       "dependencies": {
@@ -438,39 +438,39 @@
       }
     },
     "@electron-forge/template-typescript": {
-      "version": "6.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@electron-forge/template-typescript/-/template-typescript-6.0.0-beta.54.tgz",
-      "integrity": "sha512-7V87LWH+vJ1YibM9MsTttbz7upfwLrmXgchQ399EfLxK306g7q/ouyGkeTerhLr2gCUAvm/Oqx+sXQ7402ol9w==",
+      "version": "6.0.0-beta.57",
+      "resolved": "https://registry.npmjs.org/@electron-forge/template-typescript/-/template-typescript-6.0.0-beta.57.tgz",
+      "integrity": "sha512-NhcyTaLjbBGtdCTkAJgazKR4B9+yNFNH8QiXm3u6bg0cv2MhPWydmPuiEjFRLqG+Vz6jS4sW6jSIyCjFRK42ow==",
       "dev": true,
       "requires": {
-        "@electron-forge/async-ora": "6.0.0-beta.54",
-        "@electron-forge/shared-types": "6.0.0-beta.54",
-        "@electron-forge/template-base": "6.0.0-beta.54",
-        "fs-extra": "^9.0.1"
+        "@electron-forge/async-ora": "6.0.0-beta.57",
+        "@electron-forge/shared-types": "6.0.0-beta.57",
+        "@electron-forge/template-base": "6.0.0-beta.57",
+        "fs-extra": "^10.0.0"
       }
     },
     "@electron-forge/template-typescript-webpack": {
-      "version": "6.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@electron-forge/template-typescript-webpack/-/template-typescript-webpack-6.0.0-beta.54.tgz",
-      "integrity": "sha512-1MIw1eGlMZg7KLG4oAEE0rB28WDOtz01OSoW2a2NqkmUzmu4BxJdSvQ97Tp7xCU0naW0H1uU39B9QOjJQgLGCQ==",
+      "version": "6.0.0-beta.57",
+      "resolved": "https://registry.npmjs.org/@electron-forge/template-typescript-webpack/-/template-typescript-webpack-6.0.0-beta.57.tgz",
+      "integrity": "sha512-S9AzVLB02AvOwEOtQvtSJlv7BPZPSX3gdqwhoxPcTP6Pi/hOvVeEweptkwwRzGsZmSI7/ifi1bq7avhnzjasZw==",
       "dev": true,
       "requires": {
-        "@electron-forge/async-ora": "6.0.0-beta.54",
-        "@electron-forge/shared-types": "6.0.0-beta.54",
-        "@electron-forge/template-base": "6.0.0-beta.54",
-        "fs-extra": "^9.0.1"
+        "@electron-forge/async-ora": "6.0.0-beta.57",
+        "@electron-forge/shared-types": "6.0.0-beta.57",
+        "@electron-forge/template-base": "6.0.0-beta.57",
+        "fs-extra": "^10.0.0"
       }
     },
     "@electron-forge/template-webpack": {
-      "version": "6.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@electron-forge/template-webpack/-/template-webpack-6.0.0-beta.54.tgz",
-      "integrity": "sha512-4/zUOZ8MCZqs8PcUCeeG6ofpy6HT53tQiLknM23OPaFP6ckuE6kOunC6N/teijUrJuLpKl3P8d39SWPVacxEzg==",
+      "version": "6.0.0-beta.57",
+      "resolved": "https://registry.npmjs.org/@electron-forge/template-webpack/-/template-webpack-6.0.0-beta.57.tgz",
+      "integrity": "sha512-df4/jHKcZ6+8qIE+h2U9Ej5P36uGQZjI8+CcIPDE/46avHT+BwCmlMA/ZTGUQ787U9WkoMiI7122jdd7GNyuCQ==",
       "dev": true,
       "requires": {
-        "@electron-forge/async-ora": "6.0.0-beta.54",
-        "@electron-forge/shared-types": "6.0.0-beta.54",
-        "@electron-forge/template-base": "6.0.0-beta.54",
-        "fs-extra": "^9.0.1"
+        "@electron-forge/async-ora": "6.0.0-beta.57",
+        "@electron-forge/shared-types": "6.0.0-beta.57",
+        "@electron-forge/template-base": "6.0.0-beta.57",
+        "fs-extra": "^10.0.0"
       }
     },
     "@electron/get": {
@@ -1827,24 +1827,10 @@
       }
     },
     "cross-zip": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cross-zip/-/cross-zip-3.1.0.tgz",
-      "integrity": "sha512-aX02l0SD3KE27pMl69gkxDdDM5D3u9Ic4Je+2b1B2fP0dWnlWWY6ns2Vk5DEgCXJRhL3GasSpicNQRNbDkq0+w==",
-      "dev": true,
-      "requires": {
-        "rimraf": "^3.0.0"
-      },
-      "dependencies": {
-        "rimraf": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        }
-      }
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cross-zip/-/cross-zip-4.0.0.tgz",
+      "integrity": "sha512-MEzGfZo0rqE10O/B+AEcCSJLZsrWuRUvmqJTqHNqBtALhaJc3E3ixLGLJNTRzEA2K34wbmOHC4fwYs9sVsdcCA==",
+      "dev": true
     },
     "cuint": {
       "version": "0.2.2",
@@ -1919,6 +1905,12 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
       "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
+      "dev": true
+    },
+    "define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
       "dev": true
     },
     "define-properties": {
@@ -2102,6 +2094,19 @@
             "ms": "2.1.2"
           }
         },
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -2166,6 +2171,19 @@
           "requires": {
             "locate-path": "^5.0.0",
             "path-exists": "^4.0.0"
+          }
+        },
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -2316,6 +2334,19 @@
             "ms": "2.1.2"
           }
         },
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -2342,6 +2373,18 @@
           "dev": true,
           "requires": {
             "ms": "2.1.2"
+          }
+        },
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
           }
         },
         "ms": {
@@ -2398,6 +2441,18 @@
           "dev": true,
           "requires": {
             "ms": "2.1.2"
+          }
+        },
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
           }
         },
         "ms": {
@@ -2481,6 +2536,18 @@
           "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
           "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
           "dev": true
+        },
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
         },
         "get-stream": {
           "version": "5.2.0",
@@ -2569,9 +2636,9 @@
       }
     },
     "electron-winstaller": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/electron-winstaller/-/electron-winstaller-4.0.2.tgz",
-      "integrity": "sha512-tYmzIyi+W0CXd9o/jmR0VT+vwJ+nOaE/dQz8f64IlbQ/J9d2lpwsmmOKxx6veAVKeYiJHYQHR1eYsLzznNzd5g==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/electron-winstaller/-/electron-winstaller-5.0.0.tgz",
+      "integrity": "sha512-V+jFda7aVAm0htCG8Q95buPUpmXZW9ujh1HdhSlWY6y4QnJnw4TfrmxTlQWV4p2ioF/71JMI/1YF+/qbSICogA==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -3319,12 +3386,11 @@
       }
     },
     "fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+      "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
       "dev": true,
       "requires": {
-        "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
         "universalify": "^2.0.0"
@@ -3901,21 +3967,22 @@
       "dev": true
     },
     "inquirer": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
-      "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.1.0.tgz",
+      "integrity": "sha512-1nKYPoalt1vMBfCMtpomsUc32wmOoWXAoq3kM/5iTfxyQ2f/BxjixQpC+mbZ7BI0JUXHED4/XPXekDVtJNpXYw==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^4.2.1",
-        "chalk": "^4.1.0",
+        "chalk": "^4.1.1",
         "cli-cursor": "^3.1.0",
         "cli-width": "^3.0.0",
         "external-editor": "^3.0.3",
         "figures": "^3.0.0",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.21",
         "mute-stream": "0.0.8",
+        "ora": "^5.3.0",
         "run-async": "^2.4.0",
-        "rxjs": "^6.6.0",
+        "rxjs": "^6.6.6",
         "string-width": "^4.1.0",
         "strip-ansi": "^6.0.0",
         "through": "^2.3.6"
@@ -5020,13 +5087,14 @@
       }
     },
     "open": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
-      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.2.0.tgz",
+      "integrity": "sha512-O8uInONB4asyY3qUcEytpgwxQG3O0fJ/hlssoUHsBboOIRVZzT6Wq+Rwj5nffbeUhOdMjpXeISpDDzHCMRDuOQ==",
       "dev": true,
       "requires": {
-        "is-docker": "^2.0.0",
-        "is-wsl": "^2.1.1"
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
       }
     },
     "optionator": {
@@ -5484,6 +5552,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
       "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
+      "dev": true
+    },
+    "prettier": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.0.tgz",
+      "integrity": "sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==",
       "dev": true
     },
     "pretty-bytes": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2024,9 +2024,9 @@
       }
     },
     "electron": {
-      "version": "11.2.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-11.2.1.tgz",
-      "integrity": "sha512-Im1y29Bnil+Nzs+FCTq01J1OtLbs+2ZGLLllaqX/9n5GgpdtDmZhS/++JHBsYZ+4+0n7asO+JKQgJD+CqPClzg==",
+      "version": "11.4.7",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-11.4.7.tgz",
+      "integrity": "sha512-ZObBEsLrD1mIjF15tClcyDsOisOmwpE/+EcZNhBmB5N2WBjskhQHkFczNEOSTTzQ9w0kSWQUPQjLbmKQ3fD/NQ==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -59,8 +59,7 @@
     "@electron-forge/maker-zip": "6.0.0-beta.54",
     "electron": "11.2.1",
     "electron-icon-builder": "^2.0.1",
-    "eslint": "^7.19.0",
-    "node-loader": "^1.0.2"
+    "eslint": "^7.19.0"
   },
   "dependencies": {
     "electron-squirrel-startup": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "generate-icons": "electron-icon-builder --input=./icons-src/electron-swf-player-macos-icon.png --output=./",
     "make": "npm run generate-icons; electron-forge make",
     "make-win": "npm run generate-icons; electron-forge make --arch ia32,x64",
-    "lint": "echo \"No linting configured\""
+    "lint": "eslint src/**/*.js && prettier --write src/**/*.js"
   },
   "keywords": [],
   "author": {
@@ -52,14 +52,15 @@
     }
   },
   "devDependencies": {
-    "@electron-forge/cli": "6.0.0-beta.54",
-    "@electron-forge/maker-deb": "6.0.0-beta.54",
-    "@electron-forge/maker-rpm": "6.0.0-beta.54",
-    "@electron-forge/maker-squirrel": "6.0.0-beta.54",
-    "@electron-forge/maker-zip": "6.0.0-beta.54",
+    "@electron-forge/cli": "6.0.0-beta.57",
+    "@electron-forge/maker-deb": "6.0.0-beta.57",
+    "@electron-forge/maker-rpm": "6.0.0-beta.57",
+    "@electron-forge/maker-squirrel": "6.0.0-beta.57",
+    "@electron-forge/maker-zip": "6.0.0-beta.57",
     "electron": "11.2.1",
     "electron-icon-builder": "^2.0.1",
-    "eslint": "^7.19.0"
+    "eslint": "^7.27.0",
+    "prettier": "^2.3.0"
   },
   "dependencies": {
     "electron-squirrel-startup": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -57,13 +57,13 @@
     "@electron-forge/maker-rpm": "6.0.0-beta.57",
     "@electron-forge/maker-squirrel": "6.0.0-beta.57",
     "@electron-forge/maker-zip": "6.0.0-beta.57",
-    "electron": "11.2.1",
+    "electron": "^11.4.7 ",
     "electron-icon-builder": "^2.0.1",
     "eslint": "^7.27.0",
     "prettier": "^2.3.0"
   },
   "dependencies": {
     "electron-squirrel-startup": "^1.0.0",
-    "nw-flash-trust": "0.3.0"
+    "nw-flash-trust": "^0.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -60,8 +60,7 @@
     "electron": "11.2.1",
     "electron-icon-builder": "^2.0.1",
     "eslint": "^7.19.0",
-    "node-loader": "^1.0.2",
-    "style-loader": "^2.0.0"
+    "node-loader": "^1.0.2"
   },
   "dependencies": {
     "electron-squirrel-startup": "^1.0.0",

--- a/src/init-flash.js
+++ b/src/init-flash.js
@@ -1,25 +1,25 @@
-const { app } = require('electron');
-const path = require('path');
+const { app } = require("electron");
+const path = require("path");
 
 const getPlugin = () => {
-  if (process.platform === 'win32') {
-    if (process.arch === 'x64') {
+  if (process.platform === "win32") {
+    if (process.arch === "x64") {
       return {
-        pluginPath: 'pepflashplayer64_32_0_0_363.dll',
-        version: '32.0.0.363',
+        pluginPath: "pepflashplayer64_32_0_0_363.dll",
+        version: "32.0.0.363",
       };
     }
 
     return {
-      pluginPath: 'pepflashplayer32_32_0_0_363.dll',
-      version: '32.0.0.363',
+      pluginPath: "pepflashplayer32_32_0_0_363.dll",
+      version: "32.0.0.363",
     };
   }
 
-  if (process.platform === 'darwin') {
+  if (process.platform === "darwin") {
     return {
-      pluginPath: 'PepperFlashPlayer.plugin',
-      version: '30.0.0.127',
+      pluginPath: "PepperFlashPlayer.plugin",
+      version: "30.0.0.127",
     };
   }
 
@@ -36,9 +36,9 @@ module.exports = () => {
   const { pluginPath, version } = plugin;
 
   app.commandLine.appendSwitch(
-    'ppapi-flash-path',
-    path.join(__dirname, 'pepper-flash-player', pluginPath)
+    "ppapi-flash-path",
+    path.join(__dirname, "pepper-flash-player", pluginPath)
   );
 
-  app.commandLine.appendSwitch('ppapi-flash-version', version);
+  app.commandLine.appendSwitch("ppapi-flash-version", version);
 };


### PR DESCRIPTION
## What I did

- Remove style-loader
- Remove node-loader
- Update electron-forge, update eslint, add prettier, add lint command
- Update to latest version of electron 11 (the last version to support flash)
- Update package-lock.json

## Why I did it

Prepping the repo to get started on 0.3.0

## Issue #s Addressed

- closes #

## How to test it

- [ ]
